### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         run: yarn developTest
       - uses: actions/checkout@master
       - name: Publish to registy
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           registry: ghcr.io
           name: ghcr.io/afanasievkirill/telegram-swear-bot/leshin-bot


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore